### PR TITLE
Replace workflow audit mailto links with Google Form link

### DIFF
--- a/index.html
+++ b/index.html
@@ -278,7 +278,9 @@
       <div class="cta-row">
         <a
           class="btn btn-primary"
-          href="mailto:hello@aiclearinghouse.pro?subject=Request%20a%20Workflow%20Audit"
+          href="https://docs.google.com/forms/d/e/1FAIpQLSfXQ70bn5QH7C1mmLOhyf3bhUlWALE0zef6nb6p7QLc0-hb1w/viewform?usp=publish-editor"
+          target="_blank"
+          rel="noopener noreferrer"
           >Request a Workflow Audit</a
         >
         <span class="muted">Primary response goal: one discovery call scheduled.</span>
@@ -337,7 +339,7 @@
 
   <p><em>Takes 60 seconds. Just tell me your biggest workflow headache.</em></p>
 
-  <a class="btn btn-primary" href="mailto:hello@aiclearinghouse.pro?subject=Workflow%20Audit%20Request">
+  <a class="btn btn-primary" href="https://docs.google.com/forms/d/e/1FAIpQLSfXQ70bn5QH7C1mmLOhyf3bhUlWALE0zef6nb6p7QLc0-hb1w/viewform?usp=publish-editor" target="_blank" rel="noopener noreferrer">
     Request a Workflow Audit
   </a>
       


### PR DESCRIPTION
## Summary

Replaces both "Request a Workflow Audit" mailto links in `index.html` with the published Google Form URL.

### Changes
- **Hero section CTA**: `mailto:hello@aiclearinghouse.pro?subject=Request%20a%20Workflow%20Audit` → Google Form URL
- **Contact section CTA**: `mailto:hello@aiclearinghouse.pro?subject=Workflow%20Audit%20Request` → Google Form URL
- Added `target="_blank"` and `rel="noopener noreferrer"` to both links

### Verification
- Zero `mailto:` links remain for workflow audit buttons
- No copy, layout, styling, pricing, or unrelated content changed